### PR TITLE
"path" should be capitalized

### DIFF
--- a/30B10-CoefficientsOfLaurentSeries.tex
+++ b/30B10-CoefficientsOfLaurentSeries.tex
@@ -69,7 +69,7 @@ $$\operatorname{Res}(f;\,a) \;=\; r.$$
       \lim_{z\to 0}\frac{1}{1-\frac{z^2}{3!}+-\ldots} \;=\; 1,$$
 whence\, $\operatorname{Res}(\frac{1}{\sin{z}};\,0) = 1$.\, Thus we can write
 $$\oint_{\gamma}\frac{dz}{\sin{z}} \;=\; 2\pi i,$$
-where the \PMlinkescapetext{path} must be chosen such that it encloses only the pole $0$ of 
+where the \PMlinkescapetext{Path} must be chosen such that it encloses only the pole $0$ of 
 $\frac{1}{\sin{z}}$.
 \item The Taylor series of the complex exponential function gives the Laurent series
    $$e^{\frac{1}{z}} \;\equiv\; 1+\frac{1}{z}+\frac{1}{2!z^2}+\frac{1}{3!z^3}+\ldots$$


### PR DESCRIPTION
The link doesn't exist in [web page](https://planetmath.org/CoefficientsOfLaurentSeries). I think the problem is "path" should be capitalized.